### PR TITLE
add volume for ModConfigs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     volumes:
       # - ./Mods:/root/.local/share/Terraria/tModLoader/Mods
       - ./Worlds:/root/.local/share/Terraria/tModLoader/Worlds
+      - ./ModConfigs:/root/.local/share/Terraria/tModLoader/ModConfigs
       - ./serverconfig.txt:/root/terraria-server/serverconfig.txt
       - ./install.txt:/root/terraria-server/install.txt
       - ./enabled.json:/root/.local/share/Terraria/tModLoader/Mods/enabled.json


### PR DESCRIPTION
Currently all ModConfigs are lost when you restart the container.
I added a volume definition for the ModConfigs folder.